### PR TITLE
Adding server address to config options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ export default function VueSentry (Vue, options) {
   if (!options.enable) return
 
   Raven
-      .config(`${options.protocol || 'https'}://${options.key}@sentry.io/${options.project}`, {
+      .config(`${options.protocol || 'https'}://${options.key}@${options.server || 'sentry.io'}/${options.project}`, {
         ...options.config
       })
       .addPlugin(RavenVue, Vue)


### PR DESCRIPTION
Sentry can be hosted on other address so I added an option which let users to config their sentry server too